### PR TITLE
add no-op enable_ansi_support method for other platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ansi_term"
 description = "Library for ANSI terminal colours and styles (bold, underline)"
+edition = "2018"
 
 authors = [ "ogham@bsago.me", "Ryan Scheel (Havvy) <ryan.havvy@gmail.com>", "Josh Triplett <josh@joshtriplett.org>" ]
 documentation = "https://docs.rs/ansi_term"
@@ -12,6 +13,7 @@ repository = "https://github.com/ogham/rust-ansi-term"
 
 [lib]
 name = "ansi_term"
+crate-type = ["rlib", "dylib"]
 
 [features]
 derive_serde_style = ["serde"]
@@ -21,9 +23,9 @@ version = "1.0.90"
 features = ["derive"]
 optional = true
 
-[target.'cfg(target_os="windows")'.dependencies.winapi]
+[target.'cfg(target_os = "windows")'.dependencies.winapi]
 version = "0.3.4"
-features = ["errhandlingapi", "consoleapi", "processenv", "handleapi"]
+features = ["errhandlingapi", "consoleapi", "processenv", "handleapi", "fileapi"]
 
 [dev-dependencies]
 doc-comment = "0.3"

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -1,8 +1,7 @@
-use style::{Colour, Style};
-
 use std::fmt;
 
-use write::AnyWrite;
+use crate::style::{Colour, Style};
+use crate::write::AnyWrite;
 
 
 // ---- generating ANSI codes ----
@@ -284,7 +283,7 @@ impl fmt::Display for Prefix {
 
 impl fmt::Display for Infix {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use difference::Difference;
+        use crate::difference::Difference;
 
         match Difference::between(&self.0, &self.1) {
             Difference::ExtraStyles(style) => {
@@ -314,8 +313,8 @@ impl fmt::Display for Suffix {
 
 #[cfg(test)]
 mod test {
-    use style::Style;
-    use style::Colour::*;
+    use crate::style::Style;
+    use crate::style::Colour::*;
 
     macro_rules! test {
         ($name: ident: $style: expr; $input: expr => $result: expr) => {

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use style::Style;
+use crate::style::Style;
 
 
 /// Styles have a special `Debug` implementation that only shows the fields that
@@ -73,8 +73,8 @@ impl fmt::Debug for Style {
 
 #[cfg(test)]
 mod test {
-    use style::Colour::*;
-    use style::Style;
+    use crate::style::Colour::*;
+    use crate::style::Style;
 
     fn style() -> Style {
         Style::new()

--- a/src/difference.rs
+++ b/src/difference.rs
@@ -1,4 +1,4 @@
-use super::Style;
+use crate::style::Style;
 
 
 /// When printing out one coloured string followed by another, use one of
@@ -142,8 +142,8 @@ impl Difference {
 mod test {
     use super::*;
     use super::Difference::*;
-    use style::Colour::*;
-    use style::Style;
+    use crate::style::Colour::*;
+    use crate::style::Style;
 
     fn style() -> Style {
         Style::new()

--- a/src/display.rs
+++ b/src/display.rs
@@ -3,10 +3,10 @@ use std::fmt;
 use std::io;
 use std::ops::Deref;
 
-use ansi::RESET;
-use difference::Difference;
-use style::{Style, Colour};
-use write::AnyWrite;
+use crate::ansi::RESET;
+use crate::difference::Difference;
+use crate::style::{Style, Colour};
+use crate::write::AnyWrite;
 
 
 /// An `ANSIGenericString` includes a generic string type and a `Style` to
@@ -283,8 +283,8 @@ where <S as ToOwned>::Owned: fmt::Debug, &'a S: AsRef<[u8]> {
 #[cfg(test)]
 mod tests {
     pub use super::super::ANSIStrings;
-    pub use style::Style;
-    pub use style::Colour::*;
+    pub use crate::style::Colour::*;
+    pub use crate::style::Style;
 
     #[test]
     fn no_control_codes_for_plain() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,17 +229,11 @@
 //! [`fg`]: struct.Style.html#method.fg
 //! [`on`]: struct.Style.html#method.on
 
-#![crate_name = "ansi_term"]
-#![crate_type = "rlib"]
-#![crate_type = "dylib"]
-
 #![warn(missing_copy_implementations)]
 #![warn(missing_docs)]
 #![warn(trivial_casts, trivial_numeric_casts)]
 #![warn(unused_extern_crates, unused_qualifications)]
 
-#[cfg(target_os="windows")]
-extern crate winapi;
 #[cfg(test)]
 #[macro_use]
 extern crate doc_comment;
@@ -262,8 +256,8 @@ pub use display::*;
 
 mod write;
 
-mod windows;
-pub use windows::*;
+mod support;
+pub use support::*;
 
 mod util;
 pub use util::*;

--- a/src/support.rs
+++ b/src/support.rs
@@ -1,4 +1,4 @@
-/// Enables ANSI code support on Windows 10.
+/// Enables ANSI code support on Windows 10. This method is a no-op other platforms.
 ///
 /// This uses Windows API calls to alter the properties of the console that
 /// the program is running in.
@@ -55,4 +55,29 @@ pub fn enable_ansi_support() -> Result<(), u32> {
     }
 
     return Ok(());
+}
+
+/// Enables ANSI code support on Windows 10. This method is a no-op other platforms.
+///
+/// This uses Windows API calls to alter the properties of the console that
+/// the program is running in.
+///
+/// https://msdn.microsoft.com/en-us/library/windows/desktop/mt638032(v=vs.85).aspx
+///
+/// Returns a `Result` with the Windows error code if unsuccessful.
+#[cfg(not(target_os = "windows"))]
+pub fn enable_ansi_support() -> Result<(), u32> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::enable_ansi_support;
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn test_enable_ansi_support() {
+        let result = enable_ansi_support();
+        assert_eq!(result.is_ok(), true);
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,5 @@
-use display::*;
 use std::ops::Deref;
+use crate::display::*;
 
 /// Return a substring of the given ANSIStrings sequence, while keeping the formatting.
 pub fn sub_string<'a>(start: usize, len: usize, strs: &ANSIStrings<'a>) -> Vec<ANSIString<'static>> {
@@ -56,8 +56,8 @@ pub fn unstyled_len(strs: &ANSIStrings) -> usize {
 
 #[cfg(test)]
 mod test {
-    use Colour::*;
-    use display::*;
+    use crate::display::*;
+    use crate::style::Colour::*;
     use super::*;
 
     #[test]


### PR DESCRIPTION
This commit also moves the code base to the 2018 edition of Rust. This involved changing the import scheme of used modules. Crates do not need to be declared within lib.rs explicitly. The rather get pulled in as soon as they are imported via 'use' the first time